### PR TITLE
return valid (empty) path if path contains no polygons

### DIFF
--- a/lib/cartopy/mpl/path.py
+++ b/lib/cartopy/mpl/path.py
@@ -43,6 +43,9 @@ def _ensure_path_closed(path):
     finally:
         path.should_simplify = should_simplify
 
+    if len(polygons) == 0:
+        return Path(np.empty((0,2)))
+
     codes, vertices = [], []
     for poly in polygons:
         vertices.extend([poly[0], *poly])


### PR DESCRIPTION
## Rationale

While playing around in [EOmaps](https://github.com/raphaelquast/EOmaps) with overlapping clipped axes that share limits, I noticed that in case one of the clip-paths is moved completely outside the field of view, the `_ensure_path_closed` method tries to initialize a path without vertices which raises the following error:
```
ValueError: 'vertices' must be 2D with shape (N, 2), but your input has shape (0,)
```

The fix ensures that a valid (empty) path is returned in case the path contains no polygons. 